### PR TITLE
fix(build): transpile CJS bundle to ES5 syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "yarn build:es && yarn build:cjs",
     "build:es": "tsc",
-    "build:cjs": "tsc --module commonjs --outDir './dist/cjs'",
+    "build:cjs": "tsc --project tsconfig.cjs.json",
     "start": "tsc --watch",
     "lint": "foundry run eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "yarn lint --fix",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "es5",
+    "outDir": "./dist/cjs"
+  }
+}


### PR DESCRIPTION
## Purpose

Bundlers that use the CJS version usually don't transpile the code further, so it needs to be done ahead of time.

## Approach and changes

- transpile CJS bundle to ES5 syntax

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
